### PR TITLE
Introduce contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contribution Guidelines
+
+## Development
+
+### Releasing
+
+The releasing is handled at git level with semantic versioning tags. Those are automatically generated and managed
+by the [git-tag-semver-from-label-workflow](https://github.com/infrastructure-blocks/git-tag-semver-from-label-workflow).

--- a/README.md
+++ b/README.md
@@ -55,10 +55,3 @@ jobs:
     steps:
       - uses: infrastructure-blocks/composite-action-template@v1
 ```
-
-## Development
-
-### Releasing
-
-The releasing is handled at git level with semantic versioning tags. Those are automatically generated and managed
-by the [git-tag-semver-from-label-workflow](https://github.com/infrastructure-blocks/git-tag-semver-from-label-workflow).


### PR DESCRIPTION
- Split README.md into 2: README.md and CONTRIBUTING.md
- What's about the usage (and the instantiation checklist), we'll leave in
README.md
- The workings of the release flow will be documented in CONTRIBUTING.md
